### PR TITLE
Added module property to load system settings

### DIFF
--- a/core/components/commerce_printorder/lexicon/en/default.inc.php
+++ b/core/components/commerce_printorder/lexicon/en/default.inc.php
@@ -5,3 +5,5 @@ $_lang['commerce_printorder.description'] = 'Adds a button to print an order wit
 
 $_lang['commerce_printorder.print_title'] = 'Order #[[+order]]';
 $_lang['commerce_printorder.not_found'] = 'Order not found.';
+$_lang['commerce.printorder.property.system_settings'] = 'Loaded system settings';
+$_lang['commerce.printorder.property.system_settings_desc'] = 'Fill in a comma delimited list of system settings you want to use in print.twig. Will become available as: config.key';

--- a/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
+++ b/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
@@ -95,6 +95,16 @@ class PrintOrderPage extends Page
             $data['shipping_address'] = $sa->toArray();
         }
 
+        $module = $this->adapter->getObject('comModule', ['name' => 'Print Order']);
+        if ($module && $module->getProperty('system_settings')) {
+            $settings = explode(',', $module->getProperty('system_settings'));
+            if (count($settings) > 0) {
+                foreach ($settings as $key) {
+                    $data['config'][$key] = $this->adapter->getOption($key);
+                }
+            }
+        }
+
         echo $this->commerce->twig->render('printorder/print.twig', $data);
 
         @session_write_close();

--- a/core/components/commerce_printorder/src/Modules/PrintOrder.php
+++ b/core/components/commerce_printorder/src/Modules/PrintOrder.php
@@ -8,6 +8,7 @@ use RogueClarity\PrintOrder\Admin\PrintOrderPage;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
+use modmore\Commerce\Admin\Widgets\Form\TextField;
 
 require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 
@@ -65,7 +66,13 @@ class PrintOrder extends BaseModule {
 
     public function getModuleConfiguration(\comModule $module)
     {
-        $fields = [];
+        $fields[] = new TextField($this->commerce, [
+            'name'        => 'properties[system_settings]',
+            'label'       => $this->adapter->lexicon('commerce.printorder.property.system_settings'),
+            'description' => $this->adapter->lexicon('commerce.printorder.property.system_settings_desc'),
+            'value'       => $module->getProperty('system_settings')
+        ]);
+
         return $fields;
     }
 }


### PR DESCRIPTION
@tonyklapatch Real nice module! 👍  I wanted to use some extra system settings inside my twig template. Thats why I've created this pull request, which adds a module configuration option to define some system settings you can use inside the twig template.

For instance filling the config option as:
```site_url,site_name```

Then you can use these settings in your Twig template like:

```
{{ config.site_name }}
{{ config.site_url }}
```

Would love to see this PR merged and released in a new version of the module