### PR TITLE
Fix twig property

### DIFF
--- a/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
+++ b/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
@@ -122,7 +122,7 @@ class PrintOrderPage extends Page
             }
         }
 
-        echo $this->commerce->view()->twig()->render('printorder/print.twig', $data);
+        echo $this->commerce->view()->render('printorder/print.twig', $data);
 
         @session_write_close();
         exit();

--- a/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
+++ b/core/components/commerce_printorder/src/Admin/PrintOrderPage.php
@@ -122,7 +122,7 @@ class PrintOrderPage extends Page
             }
         }
 
-        echo $this->commerce->twig->render('printorder/print.twig', $data);
+        echo $this->commerce->view()->twig()->render('printorder/print.twig', $data);
 
         @session_write_close();
         exit();

--- a/core/components/commerce_printorder/src/Modules/PrintOrder.php
+++ b/core/components/commerce_printorder/src/Modules/PrintOrder.php
@@ -40,7 +40,7 @@ class PrintOrder extends BaseModule {
         // Add template path to twig
         /** @var ChainLoader $loader */
         $root = dirname(dirname(__DIR__));
-        $loader = $this->commerce->twig->getLoader();
+        $loader = $this->commerce->view()->twig()->getLoader();
         $loader->addLoader(new FilesystemLoader($root . '/templates/'));
 
         $dispatcher->addListener(\Commerce::EVENT_DASHBOARD_ORDER_ACTIONS, [$this, 'addPrintButton']);

--- a/core/components/commerce_printorder/src/Modules/PrintOrder.php
+++ b/core/components/commerce_printorder/src/Modules/PrintOrder.php
@@ -38,10 +38,7 @@ class PrintOrder extends BaseModule {
         $this->adapter->loadLexicon('commerce_printorder:default');
 
         // Add template path to twig
-        /** @var ChainLoader $loader */
-        $root = dirname(dirname(__DIR__));
-        $loader = $this->commerce->view()->twig()->getLoader();
-        $loader->addLoader(new FilesystemLoader($root . '/templates/'));
+        $this->commerce->view()->addTemplatesPath(dirname(dirname(__DIR__)) . '/templates/');
 
         $dispatcher->addListener(\Commerce::EVENT_DASHBOARD_ORDER_ACTIONS, [$this, 'addPrintButton']);
         $dispatcher->addListener(\Commerce::EVENT_DASHBOARD_INIT_GENERATOR, [$this, 'initGenerator']);


### PR DESCRIPTION
In recent versions of Commerce the `twig` property is no longer available.